### PR TITLE
Replace transitionWhile()/canTransition with intercept()/canIntercept

### DIFF
--- a/navigation_api.d.ts
+++ b/navigation_api.d.ts
@@ -103,7 +103,7 @@ declare class NavigateEvent extends Event {
   constructor(type: string, eventInit?: NavigateEventInit);
 
   readonly navigationType: NavigationType;
-  readonly canTransition: boolean;
+  readonly canIntercept: boolean;
   readonly userInitiated: boolean;
   readonly hashChange: boolean;
   readonly destination: NavigationDestination;
@@ -112,12 +112,12 @@ declare class NavigateEvent extends Event {
   readonly downloadRequest: string|null;
   readonly info: unknown;
 
-  transitionWhile(newNavigationAction: Promise<any>, options?: NavigationTransitionWhileOptions): void;
+  intercept(options?: NavigationInterceptOptions): void;
 }
 
 interface NavigateEventInit extends EventInit {
   navigationType?: NavigationType;
-  canTransition?: boolean;
+  canIntercept?: boolean;
   userInitiated?: boolean;
   hashChange?: boolean;
   destination: NavigationDestination;
@@ -127,7 +127,8 @@ interface NavigateEventInit extends EventInit {
   info?: unknown;
 }
 
-interface NavigationTransitionWhileOptions {
+interface NavigationInterceptOptions {
+  handler?: () => Promise<undefined>,
   focusReset?: "after-transition"|"manual",
   scrollRestoration?: "after-transition"|"manual"
 }

--- a/spec.bs
+++ b/spec.bs
@@ -491,7 +491,7 @@ interface NavigationTransition {
   <dd>
     <p>A {{NavigationTransition}} object representing any ongoing navigation that hasn't yet reached the {{Navigation/navigatesuccess}} or {{Navigation/navigateerror}} stage, if one exists, or null if there is no such transition ongoing.
 
-    <p>Since {{Navigation/currentEntry|navigation.currentEntry}} (and other properties like {{Location/href|location.href}}) are updated immediately upon navigation, this {{Navigation/transition|navigation.transition}} property is useful for determining when such navigations are not yet fully settled, according to any promises passed to {{NavigateEvent/transitionWhile()|event.transitionWhile()}}.
+    <p>Since {{Navigation/currentEntry|navigation.currentEntry}} (and other properties like {{Location/href|location.href}}) are updated immediately upon navigation, this {{Navigation/transition|navigation.transition}} property is useful for determining when such navigations are not yet fully settled, according to any handlers passed to {{NavigateEvent/intercept()|event.intercept()}}.
   </dd>
 
   <dt><code>{{Window/navigation}}.{{Navigation/transition}}.{{NavigationTransition/navigationType}}</code></dt>
@@ -568,19 +568,19 @@ During any given navigation, the {{Navigation}} object needs to keep track of th
       <td>So that if the navigation is canceled while the event is firing, we can [=Event/canceled flag|cancel=] the event.
     <tr>
       <td>The event's {{NavigateEvent/signal}}
-      <td>Until all promises passed to {{NavigateEvent/transitionWhile()}} have settled
+      <td>Until all promises returned from handlers passed to {{NavigateEvent/intercept()}} have settled
       <td>So that if the navigation is canceled, we can [=AbortSignal/signal abort=].
     <tr>
       <td>Whether a new element was <a spec="HTML" lt="focusing steps">focused</a>
-      <td>Until all promises passed to {{NavigateEvent/transitionWhile()}} have settled
+      <td>Until all promises returned from handlers passed to {{NavigateEvent/intercept()}} have settled
       <td>So that if one was, focus is not [=potentially reset the focus|reset=]
     <tr>
       <td>The {{NavigationHistoryEntry}} being navigated to
-      <td>From when it is determined, until all promises passed to {{NavigateEvent/transitionWhile()}} have settled
+      <td>From when it is determined, until all promises returned from handlers passed to {{NavigateEvent/intercept()}} have settled
       <td>So that we know what to [=resolve=] any {{NavigationResult/committed}} and {{NavigationResult/finished}} promises with.
     <tr>
       <td>Any {{NavigationResult/finished}} {{Promise}} that was returned
-      <td>Until all promises passed to {{NavigateEvent/transitionWhile()}} have settled
+      <td>Until all promises returned from handlers passed to {{NavigateEvent/intercept()}} have settled
       <td>So that we can [=resolve=] or [=reject=] it appropriately.
 </table>
 
@@ -615,9 +615,9 @@ During any given navigation, the {{Navigation}} object needs to keep track of th
       <td>Until the [=session history=] is updated (inside that same task)
       <td>So that we can [=resolve=] or [=reject=] it appropriately.
     <tr>
-      <td>Whether {{NavigateEvent/transitionWhile()}} was called
+      <td>Whether {{NavigateEvent/intercept()}} was called
       <td>Until the [=session history=] is updated (inside that same task)
-      <td>So that we can suppress the normal scroll restoration logic in favor of the chosen {{NavigationTransitionWhileOptions/scrollRestoration}} option value.
+      <td>So that we can suppress the normal scroll restoration logic in favor of the chosen {{NavigationInterceptOptions/scrollRestoration}} option value.
 </table>
 
 Furthermore, we need to account for the fact that there might be multiple traversals queued up, e.g. via
@@ -662,7 +662,7 @@ An <dfn>navigation API method navigation</dfn> is a [=struct=] with the followin
 * An <dfn for="navigation API method navigation">navigation object</dfn>, a {{Navigation}}
 * A <dfn for="navigation API method navigation">key</dfn>, a string or null
 * An <dfn for="navigation API method navigation">info</dfn>, a JavaScript value
-* An <dfn for="navigation API method navigation">serialized state</dfn>, a [=serialized state=] or null
+* A <dfn for="navigation API method navigation">serialized state</dfn>, a [=serialized state=] or null
 * A <dfn for="navigation API method navigation">committed-to entry</dfn>, a {{NavigationHistoryEntry}} or null
 * A <dfn for="navigation API method navigation">committed promise</dfn>, a {{Promise}}
 * A <dfn for="navigation API method navigation">finished promise</dfn>, a {{Promise}}
@@ -801,12 +801,12 @@ An <dfn>navigation API method navigation</dfn> is a [=struct=] with the followin
     * {{NavigationOptions/info}} can be set to any value; it will populate the {{NavigateEvent/info}} property of the corresponding {{Navigation/navigate}} event.
     * {{NavigationNavigateOptions/state}} can be set to any [=serializable object|serializable=] value; it will populate the state retrieved by {{NavigationHistoryEntry/getState()|navigation.currentEntry.getState()}} once the navigation completes, for same-document navigations. (It will be ignored for navigations that end up cross-document.)
 
-    <p>By default this will perform a full navigation (i.e., a cross-document navigation, unless the given URL differs only in a fragment from the current one). The {{Navigation/navigate}} event's {{NavigateEvent/transitionWhile()}} method can be used to convert it into a same-document navigation.
+    <p>By default this will perform a full navigation (i.e., a cross-document navigation, unless the given URL differs only in a fragment from the current one). The {{Navigation/navigate}} event's {{NavigateEvent/intercept()}} method can be used to convert it into a same-document navigation.
 
     <p>The returned promises will behave as follows:
 
     * For navigations that get aborted, both promises will reject with an "{{AbortError}}" {{DOMException}}.
-    * For same-document navigations created by using the {{Navigation/navigate}} event's {{NavigateEvent/transitionWhile()}} method, {{NavigationResult/committed}} will fulfill immediately, and {{NavigationResult/finished}} will fulfill or reject according to the promises passed to {{NavigateEvent/transitionWhile()}}.
+    * For same-document navigations created by using the {{Navigation/navigate}} event's {{NavigateEvent/intercept()}} method, {{NavigationResult/committed}} will fulfill immediately, and {{NavigationResult/finished}} will fulfill or reject according to any promises returned by handlers passed to {{NavigateEvent/intercept()}}.
     * For other same-document navigations (e.g., non-intercepted [=navigate to a fragment|fragment navigations=], both promises will fulfill immediately.
     * For cross-document navigations, or navigations that result in 204/205 [=response/statuses=] or `Content-Disposition: attachment` header fields from the server (and thus do not actually navigate), both promises will never settle.
 
@@ -817,12 +817,12 @@ An <dfn>navigation API method navigation</dfn> is a [=struct=] with the followin
   <dd>
     <p>Reloads the current page. The {{NavigationOptions/info}} and {{NavigationReloadOptions/state}} options behave as described above.
 
-    <p>The default behavior of performing a from-network-or-cache reload of the current page can be overriden by using the {{Navigation/navigate}} event's {{NavigateEvent/transitionWhile()}} method. Doing so will mean this call only updates state or passes along the appropriate {{NavigationOptions/info}}, plus performing whatever actions the {{Navigation/navigate}} event handler sees fit to carry out.
+    <p>The default behavior of performing a from-network-or-cache reload of the current page can be overriden by using the {{Navigation/navigate}} event's {{NavigateEvent/intercept()}} method. Doing so will mean this call only updates state or passes along the appropriate {{NavigationOptions/info}}, plus performing whatever actions the {{Navigation/navigate}} event handler sees fit to carry out.
 
     <p>The returned promises will behave as follows:
 
     * If the reload is aborted, both promises will reject with an "{{AbortError}}" {{DOMException}}.
-    * If the reload is intercepted by using the {{Navigation/navigate}} event's {{NavigateEvent/transitionWhile()}} method, {{NavigationResult/committed}} will fulfill immediately, and {{NavigationResult/finished}} will fulfill or reject according to the promises passed to {{NavigateEvent/transitionWhile()}}.
+    * If the reload is intercepted by using the {{Navigation/navigate}} event's {{NavigateEvent/intercept()}} method, {{NavigationResult/committed}} will fulfill immediately, and {{NavigationResult/finished}} will fulfill or reject according to the promises passed to {{NavigateEvent/intercept()}}.
     * Otherwise, both promises will never settle.
   </dd>
 </dl>
@@ -901,7 +901,7 @@ An <dfn>navigation API method navigation</dfn> is a [=struct=] with the followin
 
   1. [=Assert=]: |historyHandling| is either "<a for="history handling behavior">`replace`</a>", "<a for="history handling behavior">`reload`</a>", or "<a for="history handling behavior">`default`</a>".
 
-  1. Let |ongoingNavigation| be the result of [=Navigation/setting the upcoming non-traverse navigation=] for |navigation| given |info| and |serializedState|.
+  1. Let |ongoingNavigation| be the result of [=Navigation/setting the upcoming non-traverse navigation=] for |navigation| given |info|.
 
   1. <a spec="HTML">Navigate</a> |browsingContext| to |url| with <i>[=navigate/historyHandling=]</i> set to |historyHandling|, <i>[=navigate/navigationAPIState=]</i> set to |serializedState|, and the <a spec="HTML">source browsing context</a> set to |browsingContext|.
 
@@ -935,7 +935,7 @@ An <dfn>navigation API method navigation</dfn> is a [=struct=] with the followin
     <p>The returned promises will behave as follows:
 
     * If there is no {{NavigationHistoryEntry}} in {{Navigation/entries|navigation.entries}} with the given key, both will reject with an "{{InvalidStateError}}" {{DOMException}}.
-    * For same-document traversals intercepted by the {{Navigation/navigate}} event's {{NavigateEvent/transitionWhile()}} method, {{NavigationResult/committed}} will fulfill as soon as the traversal is processed and {{Navigation/currentEntry|navigation.currentEntry}} is updated, and {{NavigationResult/finished}} will fulfill or reject according to the promises passed to {{NavigateEvent/transitionWhile()}}.
+    * For same-document traversals intercepted by the {{Navigation/navigate}} event's {{NavigateEvent/intercept()}} method, {{NavigationResult/committed}} will fulfill as soon as the traversal is processed and {{Navigation/currentEntry|navigation.currentEntry}} is updated, and {{NavigationResult/finished}} will fulfill or reject according to any promises returned by handlers passed to {{NavigateEvent/intercept()}}.
     * For non-intercepted same-document traversals, both promises will fulfill as soon as the traversal is processed and {{Navigation/currentEntry|navigation.currentEntry}} is updated
     * For cross-document traversals, or traversals that result in 204/205 [=response/statuses=] or `Content-Disposition: attachment` header fields from the server (and thus do not actually traverse), both promises will never settle.
   </dd>
@@ -1083,7 +1083,7 @@ interface NavigateEvent : Event {
 
   readonly attribute NavigationType navigationType;
   readonly attribute NavigationDestination destination;
-  readonly attribute boolean canTransition;
+  readonly attribute boolean canIntercept;
   readonly attribute boolean userInitiated;
   readonly attribute boolean hashChange;
   readonly attribute AbortSignal signal;
@@ -1091,15 +1091,14 @@ interface NavigateEvent : Event {
   readonly attribute DOMString? downloadRequest;
   readonly attribute any info;
 
-  undefined transitionWhile(Promise<undefined> newNavigationAction,
-                            optional NavigationTransitionWhileOptions options = {});
+  undefined intercept(optional NavigationInterceptOptions options = {});
   undefined restoreScroll();
 };
 
 dictionary NavigateEventInit : EventInit {
   NavigationType navigationType = "push";
   required NavigationDestination destination;
-  boolean canTransition = false;
+  boolean canIntercept = false;
   boolean userInitiated = false;
   boolean hashChange = false;
   required AbortSignal signal;
@@ -1108,7 +1107,8 @@ dictionary NavigateEventInit : EventInit {
   any info;
 };
 
-dictionary NavigationTransitionWhileOptions {
+dictionary NavigationInterceptOptions {
+  NavigationInterceptHandler handler;
   NavigationFocusReset focusReset;
   NavigationScrollRestoration scrollRestoration;
 };
@@ -1122,6 +1122,8 @@ enum NavigationScrollRestoration {
   "after-transition",
   "manual"
 };
+
+callback NavigationInterceptHandler = Promise<undefined> ();
 
 enum NavigationType {
   "reload",
@@ -1141,9 +1143,9 @@ enum NavigationType {
     <p>A {{NavigationDestination}} representing the destination of the navigation.
   </dd>
 
-  <dt><code><var ignore>event</var>.{{NavigateEvent/canTransition}}</code>
+  <dt><code><var ignore>event</var>.{{NavigateEvent/canIntercept}}</code>
   <dd>
-    <p>True if {{NavigateEvent/transitionWhile()}} can be called to convert this navigation into a single-page navigation; false otherwise.
+    <p>True if {{NavigateEvent/intercept()}} can be called to intercept this navigation and convert it into a single-page navigation; false otherwise.
 
     <p>Generally speaking, this will be true whenever the current {{Document}} <a spec="HTML">can have its URL rewritten</a> to the destination URL, except for cross-document back/forward navigations, where it will always be false.
   </dd>
@@ -1191,30 +1193,28 @@ enum NavigationType {
     <p>An arbitrary JavaScript value passed via {{Window/navigation}} APIs that initiated this navigation, or null if the navigation was initiated by the user or via a non-{{Window/navigation}} API.
   </dd>
 
-  <dt><code><var ignore>event</var>.{{NavigateEvent/transitionWhile()|transitionWhile}}(|newNavigationAction|)</code>
-  <dt><code><var ignore>event</var>.{{NavigateEvent/transitionWhile()|transitionWhile}}(|newNavigationAction|, { {{NavigationTransitionWhileOptions/focusReset}}: "{{NavigationFocusReset/manual}}" })</code>
-  <dt><code><var ignore>event</var>.{{NavigateEvent/transitionWhile()|transitionWhile}}(|newNavigationAction|, { {{NavigationTransitionWhileOptions/scrollRestoration}}: "{{NavigationScrollRestoration/manual}}" })</code>
+  <dt><code><var ignore>event</var>.{{NavigateEvent/intercept()|intercept}}({ {{NavigationInterceptOptions/handler}}, {{NavigationInterceptOptions/focusReset}}, {{NavigationInterceptOptions/scrollRestoration}} })</code>
   <dd>
-    <p>Converts this navigation into a same-document navigation to the destination URL.
+    <p>Intercepts this navigation, preventing its normally handling and instead converting it into a same-document navigation to the destination URL.
 
-    <p>The given |newNavigationAction| promise is used to signal the duration, and success or failure, of the navigation. After it settles, the browser signals to the user (e.g. via a loading spinner UI, or assistive technology) that the navigation is finished. Additionally, it fires {{Navigation/navigatesuccess}} or {{Navigation/navigateerror}} events as appropriate, which other parts of the web application can respond to.
+    <p>The {{NavigationInterceptOptions/handler}} option can be a function that returns a promise. The handler function will run after the {{Navigation/navigate}} event has finished firing, and the {{Navigation/currentEntry|navigation.currentEntry}} property has been synchronously updated. This promise is used to signal the duration, and success or failure, of the navigation. After it settles, the browser signals to the user (e.g. via a loading spinner UI, or assistive technology) that the navigation is finished. Additionally, it fires {{Navigation/navigatesuccess}} or {{Navigation/navigateerror}} events as appropriate, which other parts of the web application can respond to.
 
-    <p>By default, using this method will cause focus to reset when the |newNavigationAction| promise (and any other promises passed in other calls to {{NavigateEvent/transitionWhile()}}) settle. Focus will be reset to the first element with the <{html-global/autofocus}> attribute set, or the <{body}> element if the attribute isn't present. The {{NavigationTransitionWhileOptions/focusReset}} option can be set to "{{NavigationFocusReset/manual}}" to avoid this behavior.
+    <p>By default, using this method will cause focus to reset when any handlers' returned promises settle. Focus will be reset to the first element with the <{html-global/autofocus}> attribute set, or the <{body}> element if the attribute isn't present. The {{NavigationInterceptOptions/focusReset}} option can be set to "{{NavigationFocusReset/manual}}" to avoid this behavior.
 
-    <p>By default, using this method for "{{NavigationType/traverse}}" navigations will cause the browser's scroll restoration logic to be delayed until the |newNavigationAction| promise (and any other promises passed in other calls to {{NavigateEvent/transitionWhile()}}) settle. The {{NavigationTransitionWhileOptions/scrollRestoration}} option can be set to "{{NavigationScrollRestoration/manual}}" to turn off scroll restoration entirely for this navigation, or control the timing of it by later calling {{NavigateEvent/restoreScroll()}}.
+    <p>By default, using this method for "{{NavigationType/traverse}}" navigations will cause the browser's scroll restoration logic to be delayed until any handlers' returned promises settle. The {{NavigationInterceptOptions/scrollRestoration}} option can be set to "{{NavigationScrollRestoration/manual}}" to turn off scroll restoration entirely for this navigation, or control the timing of it by later calling {{NavigateEvent/restoreScroll()}}.
 
-    <p>This method will throw a "{{SecurityError}}" {{DOMException}} if {{NavigateEvent/canTransition}} is false, or if {{Event/isTrusted}} is false. It will throw an "{{InvalidStateError}}" {{DOMException}} if not called synchronously, during event dispatch.
+    <p>This method will throw a "{{SecurityError}}" {{DOMException}} if {{NavigateEvent/canIntercept}} is false, or if {{Event/isTrusted}} is false. It will throw an "{{InvalidStateError}}" {{DOMException}} if not called synchronously, during event dispatch.
   </dd>
 
   <dt><code><var ignore>event</var>.{{NavigateEvent/restoreScroll()|restoreScroll}}()</code>
   <dd>
-    <p>For "{{NavigationType/traverse}}" navigations which have set <code>{{NavigationTransitionWhileOptions/scrollRestoration}}: "{{NavigationScrollRestoration/manual}}"</code> as part of their {{NavigateEvent/transitionWhile()}} call, restores the scroll position using the browser's usual scroll restoration logic.
+    <p>For "{{NavigationType/traverse}}" navigations which have set <code>{{NavigationInterceptOptions/scrollRestoration}}: "{{NavigationScrollRestoration/manual}}"</code> as part of their {{NavigateEvent/intercept()}} call, restores the scroll position using the browser's usual scroll restoration logic.
 
-    <p>If used on a non-"{{NavigationType/traverse}}" navigation, or on one which has not had {{NavigationTransitionWhileOptions/scrollRestoration}} set appropriately, or if called more than once, this method will throw an "{{InvalidStateError}}" {{DOMException}}.
+    <p>If used on a non-"{{NavigationType/traverse}}" navigation, or on one which has not had {{NavigationInterceptOptions/scrollRestoration}} set appropriately, or if called more than once, this method will throw an "{{InvalidStateError}}" {{DOMException}}.
   </dd>
 </dl>
 
-The <dfn attribute for="NavigateEvent">navigationType</dfn>, <dfn attribute for="NavigateEvent">destination</dfn>, <dfn attribute for="NavigateEvent">canTransition</dfn>, <dfn attribute for="NavigateEvent">userInitiated</dfn>, <dfn attribute for="NavigateEvent">hashChange</dfn>, <dfn attribute for="NavigateEvent">signal</dfn>, <dfn attribute for="NavigateEvent">formData</dfn>, <dfn attribute for="NavigateEvent">downloadRequest</dfn>, and <dfn attribute for="NavigateEvent">info</dfn> getter steps are to return the value that the corresponding attribute was initialized to.
+The <dfn attribute for="NavigateEvent">navigationType</dfn>, <dfn attribute for="NavigateEvent">destination</dfn>, <dfn attribute for="NavigateEvent">canIntercept</dfn>, <dfn attribute for="NavigateEvent">userInitiated</dfn>, <dfn attribute for="NavigateEvent">hashChange</dfn>, <dfn attribute for="NavigateEvent">signal</dfn>, <dfn attribute for="NavigateEvent">formData</dfn>, <dfn attribute for="NavigateEvent">downloadRequest</dfn>, and <dfn attribute for="NavigateEvent">info</dfn> getter steps are to return the value that the corresponding attribute was initialized to.
 
 A {{NavigateEvent}} has a <dfn for="NavigateEvent">classic history API serialized data</dfn>, a [=serialized state=]-or-null. It is only used in some cases where the event's {{NavigateEvent/navigationType}} is "{{NavigationType/push}}" or "{{NavigationType/replace}}", and is set appropriately when the event is [[#navigate-event-firing|fired]].
 
@@ -1224,23 +1224,26 @@ A {{NavigateEvent}} has a <dfn for="NavigateEvent">scroll restoration behavior</
 
 A {{NavigateEvent}} has a <dfn for="NavigateEvent">did process scroll restoration</dfn>, a boolean, initially false.
 
-A {{NavigateEvent}} has a <dfn for="NavigateEvent">navigation action promises list</dfn>, which is a [=list=] of {{Promise}} objects, initially empty.
+A {{NavigateEvent}} has a <dfn for="NavigateEvent">was intercepted</dfn>, a boolean, initially false.
+
+A {{NavigateEvent}} has a <dfn for="NavigateEvent">navigation handler list</dfn>, which is a [=list=] of {{NavigationInterceptHandler}} callbacks, initially empty.
 
 <div algorithm>
-  The <dfn method for="NavigateEvent">transitionWhile(|newNavigationAction|, |options|)</dfn> method steps are:
+  The <dfn method for="NavigateEvent">intercept(|options|)</dfn> method steps are:
 
   1. If [=this=]'s [=relevant global object=]'s [=active Document=] is not [=Document/fully active=], then throw an "{{InvalidStateError}}" {{DOMException}}.
   1. If [=this=]'s {{Event/isTrusted}} attribute was initialized to false, then throw a "{{SecurityError}}" {{DOMException}}.
-  1. If [=this=]'s {{NavigateEvent/canTransition}} attribute was initialized to false, then throw a "{{SecurityError}}" {{DOMException}}.
+  1. If [=this=]'s {{NavigateEvent/canIntercept}} attribute was initialized to false, then throw a "{{SecurityError}}" {{DOMException}}.
   1. If [=this=]'s [=Event/dispatch flag=] is unset, then throw an "{{InvalidStateError}}" {{DOMException}}.
   1. If [=this=]'s [=Event/canceled flag=] is set, then throw an "{{InvalidStateError}}" {{DOMException}}.
-  1. [=list/Append=] |newNavigationAction| to [=this=]'s [=NavigateEvent/navigation action promises list=].
-  1. If |options|["{{NavigationTransitionWhileOptions/focusReset}}"] [=map/exists=], then:
-    1. If [=this=]'s [=NavigateEvent/focus reset behavior=] is not null, and it is not equal to |options|["{{NavigationTransitionWhileOptions/focusReset}}"], then the user agent may [=report a warning to the console=] indicating that the {{NavigationTransitionWhileOptions/focusReset}} option for a previous call to {{NavigateEvent/transitionWhile()}} was overridden by this new value, and the previous value will be ignored.
-    1. Set [=this=]'s [=NavigateEvent/focus reset behavior=] to |options|["{{NavigationTransitionWhileOptions/focusReset}}"].
-  1. If |options|["{{NavigationTransitionWhileOptions/scrollRestoration}}"] [=map/exists=], and [=this=]'s {{NavigateEvent/navigationType}} attribute was initialized to "{{NavigationType/traverse}}", then:
-    1. If [=this=]'s [=NavigateEvent/scroll restoration behavior=] is not null, and it is not equal to |options|["{{NavigationTransitionWhileOptions/scrollRestoration}}"], then the user agent may [=report a warning to the console=] indicating that the {{NavigationTransitionWhileOptions/scrollRestoration}} option for a previous call to {{NavigateEvent/transitionWhile()}} was overridden by this new value, and the previous value will be ignored.
-    1. Set [=this=]'s [=NavigateEvent/scroll restoration behavior=] to |options|["{{NavigationTransitionWhileOptions/scrollRestoration}}"].
+  1. If |options|["{{NavigationInterceptOptions/handler}}"] [=map/exists=], then [=list/append=] it to [=this=]'s [=NavigateEvent/navigation handler list=].
+  1. Set [=this=]'s [=NavigateEvent/was intercepted=] to true.
+  1. If |options|["{{NavigationInterceptOptions/focusReset}}"] [=map/exists=], then:
+    1. If [=this=]'s [=NavigateEvent/focus reset behavior=] is not null, and it is not equal to |options|["{{NavigationInterceptOptions/focusReset}}"], then the user agent may [=report a warning to the console=] indicating that the {{NavigationInterceptOptions/focusReset}} option for a previous call to {{NavigateEvent/intercept()}} was overridden by this new value, and the previous value will be ignored.
+    1. Set [=this=]'s [=NavigateEvent/focus reset behavior=] to |options|["{{NavigationInterceptOptions/focusReset}}"].
+  1. If |options|["{{NavigationInterceptOptions/scrollRestoration}}"] [=map/exists=], and [=this=]'s {{NavigateEvent/navigationType}} attribute was initialized to "{{NavigationType/traverse}}", then:
+    1. If [=this=]'s [=NavigateEvent/scroll restoration behavior=] is not null, and it is not equal to |options|["{{NavigationInterceptOptions/scrollRestoration}}"], then the user agent may [=report a warning to the console=] indicating that the {{NavigationInterceptOptions/scrollRestoration}} option for a previous call to {{NavigateEvent/intercept()}} was overridden by this new value, and the previous value will be ignored.
+    1. Set [=this=]'s [=NavigateEvent/scroll restoration behavior=] to |options|["{{NavigationInterceptOptions/scrollRestoration}}"].
 </div>
 
 <div algorithm>
@@ -1292,7 +1295,7 @@ interface NavigationDestination {
   <dd>
     <p>Indicates whether or not this navigation is to the same {{Document}} as the current {{Window/document}} value, or not. This will be true, for example, in cases of fragment navigations or {{History/pushState()|history.pushState()}} navigations.
 
-    <p>Note that this property indicates the original nature of the navigation. If a cross-document navigation is converted into a same-document navigation using {{NavigateEvent/transitionWhile()|event.transitionWhile()}}, that will not change the value of this property.
+    <p>Note that this property indicates the original nature of the navigation. If a cross-document navigation is converted into a same-document navigation using {{NavigateEvent/intercept()|event.intercept()}}, that will not change the value of this property.
   </dd>
 
   <dt><code><var ignore>state</var> = <var ignore>event</var>.{{NavigateEvent/destination}}.{{NavigationDestination/getState()}}</code>
@@ -1394,13 +1397,12 @@ The <dfn attribute for="NavigationDestination">sameDocument</dfn> getter steps a
   1. [=Navigation/Promote the upcoming navigation to ongoing=] given |navigation| and |destination|'s [=NavigationDestination/key=].
   1. Let |ongoingNavigation| be |navigation|'s [=Navigation/ongoing navigation=].
   1. If |navigation| [=Navigation/has entries and events disabled=], then:
-    1. If |ongoingNavigation| is not null, then:
-      1. [=navigation API method navigation/Clean up=] |ongoingNavigation|.
+    1. If |ongoingNavigation| is not null, then [=navigation API method navigation/clean up=] |ongoingNavigation|.
 
-      <p class="note">In this case the [=navigation API method navigation/committed promise=] and [=navigation API method navigation/finished promise=] will never fulfill, since we never create {{NavigationHistoryEntry}}s for the initial `about:blank` {{Document}} so we have nothing to [=resolve=] them with.
+       <p class="note">In this case the [=navigation API method navigation/committed promise=] and [=navigation API method navigation/finished promise=] will never fulfill, since we never create {{NavigationHistoryEntry}}s for the initial `about:blank` {{Document}} so we have nothing to [=resolve=] them with.
     1. Return true.
   1. Let |document| be |navigation|'s [=relevant global object=]'s [=associated document=].
-  1. If |document| <a spec="HTML">can have its URL rewritten</a> to |destination|'s [=NavigationDestination/URL=], and either |destination|'s [=NavigationDestination/is same document=] is true or |navigationType| is not "{{NavigationType/traverse}}", then initialize |event|'s {{NavigateEvent/canTransition}} to true. Otherwise, initialize it to false.
+  1. If |document| <a spec="HTML">can have its URL rewritten</a> to |destination|'s [=NavigationDestination/URL=], and either |destination|'s [=NavigationDestination/is same document=] is true or |navigationType| is not "{{NavigationType/traverse}}", then initialize |event|'s {{NavigateEvent/canIntercept}} to true. Otherwise, initialize it to false.
   1. If |navigationType| is not "{{NavigationType/traverse}}", then initialize |event|'s {{Event/cancelable}} to true. Otherwise, initialize it to false.
   1. Initialize |event|'s {{Event/type}} to "{{Navigation/navigate}}".
   1. Initialize |event|'s {{NavigateEvent/navigationType}} to |navigationType|.
@@ -1430,21 +1432,25 @@ The <dfn attribute for="NavigationDestination">sameDocument</dfn> getter steps a
     1. If |navigationType| is not "{{NavigationType/traverse}}" and |event|'s {{NavigateEvent/signal}} is not [=AbortSignal/aborted=], then [=finalize with an aborted navigation error=] given |navigation| and |ongoingNavigation|.
        <p class="note">If |navigationType| is "{{NavigationType/traverse}}", then we will [=finalize with an aborted navigation error=] in [=perform a navigation API traversal=].
     1. Return false.
-  1. Let |hadTransitionWhile| be true if |event|'s [=NavigateEvent/navigation action promises list=] is not empty; otherwise false.
-  1. Let |endResultIsSameDocument| be true if |hadTransitionWhile| is true or |destination|'s [=NavigationDestination/is same document=] is true.
-  1. If |hadTransitionWhile| is true:
+  1. Let |endResultIsSameDocument| be true if |event|'s [=NavigateEvent/was intercepted=] is true or |destination|'s [=NavigationDestination/is same document=] is true.
+  1. If |event|'s [=NavigateEvent/was intercepted=] is true:
     1. Let |fromEntry| be the [=Navigation/current entry=] for |navigation|.
     1. [=Assert=]: |fromEntry| is not null.
     1. Set |navigation|'s [=Navigation/transition=] to a [=new=] {{NavigationTransition}} created in |navigation|'s [=relevant Realm=], whose [=NavigationTransition/navigation type=] is |navigationType|, [=NavigationTransition/from entry=] is |fromEntry|, and whose [=NavigationTransition/finished promise=] is [=a new promise=] created in |navigation|'s [=relevant Realm=].
     1. [=Mark as handled=] |navigation|'s [=Navigation/transition=]'s [=NavigationTransition/finished promise=].
       <p class="note">See <a href="#note-finished-promise-mark-as-handled">the discussion about other finished promises</a> as to why this is done.</p>
     1. If |navigationType| is "{{NavigationType/traverse}}", then set |navigation|'s [=Navigation/suppress normal scroll restoration during ongoing navigation=] to true.
-       <p class="note">If |event|'s [=NavigateEvent/scroll restoration behavior=] was set to "{{NavigationScrollRestoration/after-transition}}", then we will [=potentially perform scroll restoration=] below. Otherwise, there will be no scroll restoration. That is, no navigation which is intercepted by {{NavigateEvent/transitionWhile()}} goes through the normal scroll restoration process; scroll restoration for such navigations is either done manually, by the web developer, or is done after the transition.
+       <p class="note">If |event|'s [=NavigateEvent/scroll restoration behavior=] was set to "{{NavigationScrollRestoration/after-transition}}", then we will [=potentially perform scroll restoration=] below. Otherwise, there will be no scroll restoration. That is, no navigation which is intercepted by {{NavigateEvent/intercept()}} goes through the normal scroll restoration process; scroll restoration for such navigations is either done manually, by the web developer, or is done after the transition.
+    1. If |navigationType| is "{{NavigationType/push}}" or "{{NavigationType/replace}}", then run the [=URL and history update steps=] given |document| and |event|'s {{NavigateEvent/destination}}'s [=NavigationDestination/URL=], with <i>[=URL and history update steps/serializedData=]</i> set to |event|'s [=NavigateEvent/classic history API serialized data=] and <i>[=URL and history update steps/historyHandling=]</i> set to |navigationType|.
+
+       <p class="note">If |navigationType| is "{{NavigationType/reload}}", then we are converting a reload into a "same-document reload", for which the <a spec="HTML">URL and history update steps</a> are not appropriate. Navigation API-related stuff still happens, such as updating the [=session history/current entry=]'s [=session history entry/navigation API state=] if this was caused by a call to {{Navigation/reload()|navigation.reload()}}, and all the <a href="#ongoing-state">ongoing navigation tracking</a>.
   1. If |endResultIsSameDocument| is true:
-    1. Let |tweakedPromisesList| be |event|'s  [=NavigateEvent/navigation action promises list=].
-    1. If |tweakedPromisesList|'s [=list/size=] is 0, then set |tweakedPromisesList| to « [=a promise resolved with=] {{undefined}} ».
+    1. Let |promisesList| be an empty [=list=].
+    1. [=list/For each=] |handler| of |event|'s [=NavigateEvent/navigation handler list=]:
+      1. [=list/Append=] the result of [=invoking=] |handler| to |promisesList| with an empty arguments list.
+    1. If |promisesList|'s [=list/size=] is 0, then set |promisesList| to « [=a promise resolved with=] {{undefined}} ».
        <p class="note">There is a subtle timing difference between how [=waiting for all=] schedules its success and failure steps when given zero promises versus &geq;1 promises. For most uses of [=waiting for all=], this does not matter. However, with this API, there are so many events and promise handlers which could fire around the same time that the difference is pretty easily observable: it can cause the event/promise handler sequence to vary. (Some of the events and promises involved include: {{Navigation/navigatesuccess}} / {{Navigation/navigateerror}}, {{Navigation/currententrychange}}, {{NavigationHistoryEntry/dispose}}, |ongoingNavigation|'s promises, and the {{NavigationTransition/finished|navigation.transition.finished}} promise.)
-    1. [=Wait for all=] of |tweakedPromisesList|, with the following success steps:
+    1. [=Wait for all=] of |promisesList|, with the following success steps:
         1. If |event|'s {{NavigateEvent/signal}} is [=AbortSignal/aborted=], then abort these steps.
         1. [=Fire an event=] named {{Navigation/navigatesuccess}} at |navigation|.
         1. If |navigation|'s [=Navigation/transition=] is not null, then [=resolve=] |navigation|'s [=Navigation/transition=]'s [=NavigationTransition/finished promise=] with undefined.
@@ -1461,11 +1467,7 @@ The <dfn attribute for="NavigationDestination">sameDocument</dfn> getter steps a
         1. [=Potentially reset the focus=] given |navigation| and |event|.
            <p class="note">Although we still [=potentially reset the focus=] for such failed transitions, we do <em>not</em> [=potentially perform scroll restoration=] for them.
   1. Otherwise, if |ongoingNavigation| is non-null, then [=navigation API method navigation/clean up=] |ongoingNavigation|.
-  1. If |hadTransitionWhile| is true and |navigationType| is not "{{NavigationType/traverse}}":
-    1. If |navigationType| is not "{{NavigationType/reload}}", then run the [=URL and history update steps=] given |document| and |event|'s {{NavigateEvent/destination}}'s [=NavigationDestination/URL=], with <i>[=URL and history update steps/serializedData=]</i> set to |event|'s [=NavigateEvent/classic history API serialized data=] and <i>[=URL and history update steps/historyHandling=]</i> set to |navigationType|.
-
-       <p class="note">If |navigationType| is "{{NavigationType/reload}}", then we are converting a reload into a "same-document reload", for which the <a spec="HTML">URL and history update steps</a> are not appropriate. Navigation API-related stuff still happens, such as updating the [=session history/current entry=]'s [=session history entry/navigation API state=] if this was caused by a call to {{Navigation/reload()|navigation.reload()}}, and all the <a href="#ongoing-state">ongoing navigation tracking</a> in response to the promise passed to {{NavigateEvent/transitionWhile()}}.
-    1. Return false.
+  1. If |event|'s [=NavigateEvent/was intercepted=] is true and |navigationType| is "{{NavigationType/push}}", "{{NavigationType/replace}}", or "{{NavigationType/reload}}", then return false.
   1. Return true.
 </div>
 
@@ -1512,7 +1514,7 @@ The <dfn attribute for="NavigationDestination">sameDocument</dfn> getter steps a
   1. Let |focusChanged| be |navigation|'s [=Navigation/focus changed during ongoing navigation=].
   1. Set |navigation|'s [=Navigation/focus changed during ongoing navigation=] to false.
   1. If |focusChanged| is true, then return.
-  1. If |event|'s [=NavigateEvent/navigation action promises list=]'s [=list/size=] is 0, then return.
+  1. If |event|'s [=NavigateEvent/was intercepted=] is false, then return.
   1. If |event|'s [=NavigateEvent/focus reset behavior=] is "{{NavigationFocusReset/manual}}", then return.
      <p class="note">If it was left as null, then we treat that as "{{NavigationFocusReset/after-transition}}", and continue onward.
   1. Let |document| be |navigation|'s [=relevant global object=]'s [=associated Document=].
@@ -1526,7 +1528,7 @@ The <dfn attribute for="NavigationDestination">sameDocument</dfn> getter steps a
 <div algorithm>
   To <dfn>potentially perform scroll restoration</dfn> given a {{Navigation}} object |navigation| and an {{NavigateEvent}} |event|:
 
-  1. If |event|'s [=NavigateEvent/navigation action promises list=]'s [=list/size=] is 0, then return.
+  1. If |event|'s [=NavigateEvent/was intercepted=] is false, then return.
   1. If |event|'s {{NavigateEvent/navigationType}} was not initialized to "{{NavigationType/traverse}}", then return.
   1. If |event|'s [=NavigateEvent/scroll restoration behavior=] is "{{NavigationScrollRestoration/manual}}", then return.
      <p class="note">If it was left as null, then we treat that as "{{NavigationScrollRestoration/after-transition}}", and continue onward.
@@ -1946,17 +1948,17 @@ We do not [=Navigation/update the entries=] when initially <a spec="HTML">creati
 
 <h3 id="focus-patches">Focus tracking</h3>
 
-To support the {{NavigationTransitionWhileOptions/focusReset}} option, the following patches need to be made:
+To support the {{NavigationInterceptOptions/focusReset}} option, the following patches need to be made:
 
 Update the <a spec="HTML">focusing steps</a> to, right before they call the <a spec="HTML">focus update steps</a>, set the {{Document}}'s [=relevant global object=]'s [=Window/navigation API=]'s [=Navigation/focus changed during ongoing navigation=] to true.
 
 Update the <a spec="HTML">focus fixup rule</a> to additionally set the {{Document}}'s [=relevant global object=]'s [=Window/navigation API=]'s [=Navigation/focus changed during ongoing navigation=] to false.
 
-<p class="note">In combination, these ensure that the [=Navigation/focus changed during ongoing navigation=] reflects any developer- or user-initiated focus changes, unless they were undone by the focus fixup rule. For example, if the user moved focus to an element which was removed from the DOM while the promise passed to {{NavigateEvent/transitionWhile()}} was settling, then that would not count as a focus change.
+<p class="note">In combination, these ensure that the [=Navigation/focus changed during ongoing navigation=] reflects any developer- or user-initiated focus changes, unless they were undone by the focus fixup rule. For example, if the user moved focus to an element which was removed from the DOM while the promise returned from a handler passed to {{NavigateEvent/intercept()}} was settling, then that would not count as a focus change.
 
 <h3 id="scroll-restoration-patches">Scroll restoration</h3>
 
-To support the {{NavigationTransitionWhileOptions/scrollRestoration}} option, as well as to fix <a href="https://github.com/whatwg/html/issues/7517">whatwg/html#7517</a>, the following patches need to be made:
+To support the {{NavigationInterceptOptions/scrollRestoration}} option, as well as to fix <a href="https://github.com/whatwg/html/issues/7517">whatwg/html#7517</a>, the following patches need to be made:
 
 Add a boolean, <dfn for="Document">has been scrolled by the user</dfn>, initially false, to {{Document}} objects. State that if the user scrolls the document, the user agent must set that document's [=Document/has been scrolled by the user=] to true. Modify the <a spec="HTML">unload a document</a> algorithm to set this back to false.
 
@@ -2004,7 +2006,11 @@ The navigation API introduces a new complication here, which is that a navigatio
 
 <xmp highlight="js">
 navigation.addEventListener("navigate", e => {
-  e.transitionWhile(new Promise(r => setTimeout(r, 1_000)));
+  e.intercept({
+    handler() {
+      return new Promise(r => setTimeout(r, 1_000));
+    }
+  });
   e.signal.addEventListener("abort", () => { ... });
 });
 


### PR DESCRIPTION
Fixes #230. Mini-explainer:

The `"navigate"` event provided by the navigation API has a method on its `NavigateEvent` instance, `event.transitionWhile(promise, options)`. This method would intercept the navigation, convert it into a same-document navigation, and then use the provided promise to signal to the browser and to other parts of the web application that we were in a transitional phase while the new navigation finishes up.

However, the signature of `transitionWhile(promise)` worked poorly in practice. The most important reason is the common coding pattern of:

```js
event.transitionWhile((async () => {
  doSyncStuff();
  await doAsyncStuff();
})());
```

i.e., the common pattern of generating a promise via an immediately-invoked async function. The problem with this pattern is that it's equivalent to


```js
doSyncStuff();
event.transitionWhile((async () => {
  await doAsyncStuff();
})());
```

This means some portion of your "navigation handling code" would run, _before_ the `navigate` event had finished firing and the URL/entry had been updated.

We know of at least two bad examples of this:

- When you synchronously modify the DOM. This throws off scroll restoration logic, as discussed in #230 (with detail at https://github.com/WICG/navigation-api/issues/230#issuecomment-1137891972). Because the sync code is modifying the DOM of the starting entry, not the destination entry.

- When you are trying to create a redirect. See https://github.com/WICG/navigation-api/issues/124#issuecomment-869804711. If you can synchronously determine you want to redirect, you need to do one behavior (canceling the current navigation, then starting a new one), whereas if you need to use async logic, then you need to do another behavior (replacing the current page). We proposed creating a first-class `navigation.transition.redirect()` helper to abstract this logic, but it's not a great sign that we'd need to create such a helper in the first place.

**Our solution is to replace `transitionWhile(promise, options)` with `intercept({ handler, ...options })`.** Essentially, we are replacing the idea of you passing a promise---which people would often generate with an async function---with the idea of you passing an async function directly. Then, the user agent can be sure to schedule the entirety of the async function _after_ the `navigate` event has finished firing, and the URL/entry updated. This avoids the above problems.

This particular API shape has other minor benefits:

- Code such as
  
  ```js
  event.transitionWhile((async () => {
    // ... many lines here ...
  })(), { focusReset: "manual" });
  ```

  hid some fairly-important information (the `focusReset: "manual"`) down at the bottom. With the new structure, we can instead write

  ```js
  event.intercept({
    focusReset: "manual",
    async handler() {
      // ... many lines here ...
    }
  });
  ```

- It is common in applications that are just starting to use the navigation API, and are not yet ready to centralize their routing logic into the `"navigate"` event handler, to simply want to intercept the navigation and convert it into a navigation-API-handled one, but leave the rest of their application as the one that reacts to this navigation. Previously this would require

  ```js
  event.transitionWhile(Promise.resolve());
  ```

  which felt like a hack. ("I want to transition, while an already-fulfilled promise is outstanding"!?) Now it is simply

  ```js
  event.intercept();
  ```

  which communicates the intent better.

- The immediately-invoked async function pattern was ugly. So ugly we were contemplating JavaScript language and Web IDL-level changes to get rid of it. See #40 and https://github.com/whatwg/webidl/issues/1020. These changes are now not necessary, at least for our API.

- This change slightly reduces (but does not fully remove) the confusion between the navigation API's notion of a navigation transition, and the in-progress shared element transitions spec's idea of a navigation transition. See https://github.com/WICG/shared-element-transitions/issues/143. The reason it does not eliminate it is that `navigation.transition` still exists. (We may settle this by renaming `navigation.transition`; see https://github.com/WICG/navigation-api/issues/230#issuecomment-1145418960.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/navigation-api/pull/235.html" title="Last updated on Jun 15, 2022, 4:58 PM UTC (e057298)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/navigation-api/235/388d56f...e057298.html" title="Last updated on Jun 15, 2022, 4:58 PM UTC (e057298)">Diff</a>