### PR TITLE
Editorial: use now-working HTTP header autolink syntax

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -50,8 +50,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: discard; url: window-object.html#a-browsing-context-is-discarded
   type: method
     for: Document; text: open(unused1, unused2); url: multipage/dynamic-markup-insertion.html#dom-document-open
-  type: http-header
-    text: Cross-Origin-Opener-Policy; url: multipage/iana.html#cross-origin-opener-policy-2
 spec: html; urlPrefix: https://whatpr.org/html/6315/
   type: dfn
     text: session history traversal queue; for: traversable navigable; url: history.html#tn-session-history-traversal-queue
@@ -262,7 +260,7 @@ Each {{Navigation}} object has an associated <dfn for="Navigation">current entry
   1. Let |sessionHistory| be |navigation|'s [=relevant global object=]'s [=Window/browsing context=]'s [=session history=].
 
      <div class="note">
-      <p>It is expected that this include session history entries in the entire [=browsing session=], including those in different <a spec="HTML">browsing context groups</a> due to \`<a http-header>`Cross-Origin-Opener-Policy`</a>\`-induced switches. This will be better-defined when <a href="https://github.com/whatwg/html/pull/6315">whatwg/html#6315</a> is finalized; see also <a href="https://github.com/whatwg/html/issues/6356">whatwg/html#6356</a> for some discussion of the impact of manual navigation on this "session" concept.
+      <p>It is expected that this include session history entries in the entire [=browsing session=], including those in different <a spec="HTML">browsing context groups</a> due to [:Cross-Origin-Opener-Policy:]-induced switches. This will be better-defined when <a href="https://github.com/whatwg/html/pull/6315">whatwg/html#6315</a> is finalized; see also <a href="https://github.com/whatwg/html/issues/6356">whatwg/html#6356</a> for some discussion of the impact of manual navigation on this "session" concept.
 
       <p>Note that it is OK to expose the data in these entries to the current page through {{NavigationHistoryEntry}} instances, since any [=session history entry/navigation API state=] will have been put there affirmatively, and the [=session history entry/URL=] is hidden appropriately by the {{NavigationHistoryEntry/url|url}} getter when the [=session history entry/document=] indicates that its URL is sensitive through the <a>"`no-referrer`"</a> or <a>"`origin`"</a> [=referrer policies=].
     </div>
@@ -1728,7 +1726,7 @@ Modify the <a spec="HTML">navigate</a> algorithm to take an optional named argum
   A user agent may provide various ways for the user to explicitly cause a browsing context to <a spec="HTML">navigate</a>, in addition to those defined in this specification.<ins> Such cases must set the <i>[=navigate/userInvolvement=]</i> argument to "<code>[=user navigation involvement/browser UI=]</code>".</ins>
 </blockquote>
 
-<p class="note">This infrastructure partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the \`<a http-header><code>Sec-Fetch-Site</code></a>\` spec at the same time.</p>
+<p class="note">This infrastructure partially solves <a href="https://github.com/whatwg/html/issues/5381">whatwg/html#5381</a>, and it'd be ideal to update the [:Sec-Fetch-Site:] spec at the same time.</p>
 
 Modify the [=navigate to a fragment=] algorithm to take a new <var ignore>userInvolvement</var> argument. Then, update the call to it from <a spec="HTML">navigate</a> to set <i>[=navigate/userInvolvement=]</i> to this <var ignore>userInvolvement</var> value.
 


### PR DESCRIPTION
Now that https://github.com/tabatkins/bikeshed/issues/2332 is fixed, we can do this.

---

The relevant Bikeshed commit doesn't seem to have made its way into an actual release or onto the CSSWG server yet, so marking as "do not merge yet" until that happens.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/navigation-api/pull/251.html" title="Last updated on Oct 31, 2022, 5:57 AM UTC (c30cb6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/navigation-api/251/a430943...c30cb6a.html" title="Last updated on Oct 31, 2022, 5:57 AM UTC (c30cb6a)">Diff</a>