### PR TITLE
Fix/update Typescript types

### DIFF
--- a/navigation_api.d.ts
+++ b/navigation_api.d.ts
@@ -129,7 +129,7 @@ interface NavigateEventInit extends EventInit {
 }
 
 interface NavigationInterceptOptions {
-  handler?: () => Promise<undefined>,
+  handler?: () => Promise<void>,
   focusReset?: "after-transition"|"manual",
   scroll?: "after-transition"|"manual"
 }

--- a/navigation_api.d.ts
+++ b/navigation_api.d.ts
@@ -110,7 +110,7 @@ declare class NavigateEvent extends Event {
   readonly signal: AbortSignal;
   readonly formData: FormData|null;
   readonly downloadRequest: string|null;
-  readonly info: unknown;
+  readonly info?: unknown;
 
   intercept(options?: NavigationInterceptOptions): void;
   scroll(): void;


### PR DESCRIPTION
## Commit 1:
### refactor(types): NavigationInterceptOptions handler should return Promise<void>

Having the handler a `Promise<undefined>` makes it a little awkward to
implement, requiring an explicit `return undefined` at times.

`Promise<void>` allows for omitting an explicit return when using an
async function.

[Example](https://stackblitz.com/edit/t8zvpm?file=index.ts&view=editor)

## Commit 2
### fix(types): Make info optional on NavigateEvent

I believe `info` should be optional on the `NavigateEvent` given that it
is optional in the `NavigateEventInit` and my experimentation revealed
that it is indeed `undefined` if not set in the `NavigationNavigateOptions`.